### PR TITLE
Publish with pnpm instead of npm

### DIFF
--- a/src/releaseMe.ts
+++ b/src/releaseMe.ts
@@ -205,9 +205,9 @@ async function publishBoilerplates(boilerplatePackageJson: string) {
   await npmPublish(path.dirname(boilerplatePackageJson))
 }
 async function npmPublish(dir: string, tag?: string) {
-  logTitle('Npm publish')
+  logTitle('Pnpm publish')
   const env = getNpmFix()
-  let cmd = 'npm publish'
+  let cmd = 'pnpm publish'
   if (tag) {
     cmd = `${cmd} --tag ${tag}`
   }


### PR DESCRIPTION
It automatically replaces `workspace:` and `catalog:` if they are present